### PR TITLE
Change Game.drawText coordinate system and drawing location

### DIFF
--- a/Game.java
+++ b/Game.java
@@ -10,6 +10,7 @@ import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.awt.Font;
+import java.awt.FontMetrics;
 import java.util.Date;
 import java.util.HashMap;
 
@@ -144,9 +145,13 @@ public class Game extends JFrame implements KeyListener, MouseListener, MouseMot
             this.buffer.fillRect(0, 0, Game.this.windowWidth, Game.this.windowHeight);
         }
 
+        // Draw Text centered at position
         public void drawText(String text, Font font, Vector2D position) {
+            FontMetrics metrics = this.buffer.getFontMetrics(font);
+            int x = (int)Math.rint(position.x - metrics.stringWidth(text)/2);
+            int y = (int)Math.rint(Game.this.windowHeight - position.y - metrics.getHeight()/2);
             this.buffer.setFont(font);
-            this.buffer.drawString(text, (int)Math.rint(position.x), (int)Math.rint(position.y));
+            this.buffer.drawString(text, x, y);
         }
 
         public void drawSprite(BufferedImage sprite, Vector2D position, Vector2D scale, int rotation) {


### PR DESCRIPTION
Game.drawText was drawing text by placing the texts bottom left hand
corner on the specified position. This has been changed to draw text
similarly to how sprites are currently drawn: centering the drawn object
on the passed in coordinates. The length of the text and the height of
the font is taken into account to center the text on the specified
point.

Game.drawText has also been changed to use the same coordinate system as
drawing sprites- with a (0,0) origin at the bottom left of the screen.

Resolves #5 